### PR TITLE
do not watch for file changes to filters

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var filters = require('./filters'),
 module.exports = function (env) {
   if (!env) {
     // instantiate a new nunjucks environment
-    env = nunjucks.configure('.', { autoescape: true });
+    env = nunjucks.configure('.', { autoescape: true, watch: false });
     // set up filters
     filters(env);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nunjucks-filters",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Useful nunjucks filters",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Watching for file changes breaks anyone else who are also using file watchers.  It's not needed for filters by default.
