### PR TITLE
getContext updated for nunjucks v2

### DIFF
--- a/filters/data/getContext.js
+++ b/filters/data/getContext.js
@@ -1,4 +1,12 @@
 'use strict';
+var _ = require('lodash');
+
 module.exports = function () {
-  return this.ctx;
+  var arrayLike = _.pick(this.ctx, function (val, key) {
+    return !isNaN(parseInt(key));
+  });
+
+  // in nunjucks v2.x, this.ctx is an object
+  // grab the numbered keys and put them back into an array
+  return _.values(arrayLike);
 };


### PR DESCRIPTION
Since `this.ctx` is now an object consisting of the old context _plus everything else at the current scope_, our `getContext` filter has to be updated to maintain compatibility.
