### PR TITLE
fixed includefile

### DIFF
--- a/filters/data/getContext.js
+++ b/filters/data/getContext.js
@@ -2,7 +2,7 @@
 var _ = require('lodash');
 
 module.exports = function () {
-  var arrayLike = _.pick(this.ctx, function (val, key) {
+  var arrayLike = _.pickBy(this.ctx, function (val, key) {
     return !isNaN(parseInt(key));
   });
 

--- a/filters/files/includeFile.js
+++ b/filters/files/includeFile.js
@@ -4,6 +4,6 @@ module.exports = function (path) {
   try {
     return fs.readFileSync(path);
   } catch (e) {
-    return e.message;
+    return '';
   }
 };

--- a/filters/files/includeFile.js
+++ b/filters/files/includeFile.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 
 module.exports = function (path) {
   try {
-    return fs.readFileSync(path);
+    return fs.readFileSync(path).toString();
   } catch (e) {
     return '';
   }

--- a/filters/files/includeFile.js
+++ b/filters/files/includeFile.js
@@ -1,10 +1,9 @@
-'use strict';
 var fs = require('fs');
 
 module.exports = function (path) {
-  if (fs.existsSync(path)) {
+  try {
     return fs.readFileSync(path);
-  } else {
-    return '';
+  } catch (e) {
+    return e.message;
   }
 };

--- a/filters/files/includeFile.test.js
+++ b/filters/files/includeFile.test.js
@@ -3,15 +3,15 @@ var filterName = __filename.split('/').pop().split('.').shift(),
   expect = require('chai').expect;
 
 describe('Filters: ' + filterName, function () {
-  it('return emptystring on empty', function () {
+  it('returns emptystring on empty', function () {
     expect(filter()).to.equal('');
   });
 
-  it('return buffer with toString method', function () {
-    expect(filter('test/mocha.opts').toString).to.be.instanceof(Function);
+  it('returns emptystring on error', function () {
+    expect(filter('not/a/path/to/any/file')).to.equal('');
   });
 
-  it('return emptystring on error', function () {
-    expect(filter('not/a/path/to/any/file')).to.equal('');
+  it('returns string', function () {
+    expect(filter('test/mocha.opts')).to.equal('--reporter dot\n--ui bdd\n--recursive\nfilters/**/*.js');
   });
 });

--- a/filters/files/includeFile.test.js
+++ b/filters/files/includeFile.test.js
@@ -3,11 +3,15 @@ var filterName = __filename.split('/').pop().split('.').shift(),
   expect = require('chai').expect;
 
 describe('Filters: ' + filterName, function () {
-  it('return false on empty', function () {
-    expect(filter()).to.be.falsy;
+  it('return emptystring on empty', function () {
+    expect(filter()).to.equal('');
   });
 
-  it('return object with toString method', function () {
+  it('return buffer with toString method', function () {
     expect(filter('test/mocha.opts').toString).to.be.instanceof(Function);
+  });
+
+  it('return emptystring on error', function () {
+    expect(filter('not/a/path/to/any/file')).to.equal('');
   });
 });

--- a/filters/files/includeFile.test.js
+++ b/filters/files/includeFile.test.js
@@ -1,4 +1,3 @@
-'use strict';
 var filterName = __filename.split('/').pop().split('.').shift(),
   filter = require('./' + filterName),
   expect = require('chai').expect;

--- a/filters/files/includeFile.test.js
+++ b/filters/files/includeFile.test.js
@@ -8,7 +8,7 @@ describe('Filters: ' + filterName, function () {
     expect(filter()).to.be.falsy;
   });
 
-  it('return Buffer type', function () {
-    expect(filter('test/mocha.opts')).to.be.instanceof(Buffer);
+  it('return object with toString method', function () {
+    expect(filter('test/mocha.opts').toString).to.be.instanceof(Function);
   });
 });

--- a/filters/index.js
+++ b/filters/index.js
@@ -1,6 +1,9 @@
-'use strict';
-var glob = require('glob'),
+const glob = require('glob'),
   _ = require('lodash');
+
+function isFilter(path) {
+  return !_.includes(path, '.test.js') && !_.includes(path, 'index.js');
+}
 
 function getNameFromPath(path) {
   return path.split('/').pop().split('.').shift();
@@ -9,7 +12,11 @@ function getNameFromPath(path) {
 module.exports = function (env, cb) {
   // options is optional
   glob('./**/*.js', { cwd: __dirname }, function (err, files) {
-    _.each(_.filter(files, function (file) { return file.indexOf('.test.js') === -1 && file.indexOf('index.js') === -1; }), function (file) {
+    if (err) {
+      console.error(err.message, err.stack);
+    }
+
+    _.each(_.filter(files, isFilter), function (file) {
       var filter = require(file);
 
       if (_.isFunction(filter)) {

--- a/filters/index.js
+++ b/filters/index.js
@@ -9,7 +9,7 @@ function getNameFromPath(path) {
 module.exports = function (env, cb) {
   // options is optional
   glob('./**/*.js', { cwd: __dirname }, function (err, files) {
-    _.each(_.filter(files, function (file) { return file.indexOf('.test.js') === -1; }), function (file) {
+    _.each(_.filter(files, function (file) { return file.indexOf('.test.js') === -1 && file.indexOf('index.js') === -1; }), function (file) {
       var filter = require(file);
 
       if (_.isFunction(filter)) {

--- a/filters/math/sum.js
+++ b/filters/math/sum.js
@@ -14,7 +14,7 @@ module.exports = function (iterable, keywords) {
 
   if (_.isArray(iterable)) {
     if (_.isString(attribute)) {
-      iterable = _.pluck(iterable, attribute);
+      iterable = _.map(iterable, attribute);
     }
     result = _.reduce(iterable, function (num, value) {
       num += value;

--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@ module.exports = function (env) {
   if (!env) {
     // instantiate a new nunjucks environment
     env = nunjucks.configure('.');
-    // set up filters
-    filters(env);
   }
 
   // set up filters


### PR DESCRIPTION
- removed `fs.statSync` check, as it's a node antipattern
- `includeFile` now returns the string itself, rather than a buffer
- added more tests for `includeFile`
- updated to fix lodash v3 → v4 upgrade issues
- added error handling for filter init
- removed garbage code that was initializing the filters twice
